### PR TITLE
Remove exportAAF definition and documentation for now

### DIFF
--- a/src/pages/ppro_reference/classes/projectconverter.md
+++ b/src/pages/ppro_reference/classes/projectconverter.md
@@ -21,35 +21,6 @@ keywords:
 
 ## Static Methods
 
-### exportAAF
-
-<span class="minversion" style="display: block; margin-bottom: -1em; margin-left: 36em; float:left; opacity:0.5;">25.0</span>
-
-*boolean*
-  
-Export a sequence as an AAF (Advanced Authoring Format) file to the specified output path.
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| sequence | [*Sequence*](/ppro_reference/classes/sequence/) | - |
-| filePath | *string* | - |
-| mixdownVideo | *boolean* | - |
-| explodeToMono | *boolean* | - |
-| sampleRate | *number* | - |
-| bitsPerSample | *number* | - |
-| embedAudio | *boolean* | - |
-| audioFileFormat | *number* | - |
-| trimSources | *boolean* | - |
-| handleFrames | *number* | - |
-| videoMixdownPresetPath | *string* | - |
-| renderAudioEffects | *boolean* | - |
-| interleaveWithoutEffects | *boolean* | - |
-| preserveParentFolder | *boolean* | - |
-
-___
-
 ### exportAsFinalCutProXML
 
 <span class="minversion" style="display: block; margin-bottom: -1em; margin-left: 36em; float:left; opacity:0.5;">25.0</span>

--- a/src/pages/ppro_reference/types.d.ts
+++ b/src/pages/ppro_reference/types.d.ts
@@ -2281,26 +2281,6 @@ export declare type ProjectColorSettings = {
 export declare type ProjectConverterStatic = {
 
   /**
-   * Export a sequence as an AAF (Advanced Authoring Format) file to the specified output path.
-   *
-   * @param sequence
-   * @param filePath
-   * @param mixdownVideo
-   * @param explodeToMono
-   * @param sampleRate
-   * @param bitsPerSample
-   * @param embedAudio
-   * @param audioFileFormat
-   * @param trimSources
-   * @param handleFrames
-   * @param videoMixdownPresetPath
-   * @param renderAudioEffects
-   * @param interleaveWithoutEffects
-   * @param preserveParentFolder
-   */
-  exportAAF(sequence: Sequence, filePath: string, mixdownVideo: boolean, explodeToMono: boolean, sampleRate: number, bitsPerSample: number, embedAudio: boolean, audioFileFormat: number, trimSources: boolean, handleFrames: number, videoMixdownPresetPath: string, renderAudioEffects?: boolean, interleaveWithoutEffects?: boolean, preserveParentFolder?: boolean): Promise<boolean>
-
-  /**
    * Export a sequence as Final Cut Pro XML to the specified output file path.
    *
    * @param sequence


### PR DESCRIPTION
This reverts commit f98463bc9db6b3246d49432afa947501c52dad9d, reversing changes made to 1282f7ea2ab2a9c62cb8b30dca51cc58ab5b49c7.

Removing type definitions and docs for exportAAF