### PR TITLE
Update minversion for setVideoFrameRate() to 26.2

### DIFF
--- a/src/pages/ppro_reference/classes/sequencesettings.md
+++ b/src/pages/ppro_reference/classes/sequencesettings.md
@@ -359,7 +359,7 @@ ___
 
 ### setVideoFrameRate
 
-<span class="minversion" style="display: block; margin-bottom: -1em; margin-left: 36em; float:left; opacity:0.5;">25.0</span>
+<span class="minversion" style="display: block; margin-bottom: -1em; margin-left: 36em; float:left; opacity:0.5;">26.2 (beta)</span>
 
 *boolean*
   


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

setVideoFrameRate() is not currently supported on version 25, and is introduced in Premiere v26.2 (beta). Thus, the UXP API documentation should reflect this.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The current documentation is confusing as it explains that setVideoFrameRate() was introduced in v25, when it was introduced in v26.2.

## How Has This Been Tested?

I tried to make a Premiere plugin with UXP, and ran into an issue using setVideoFrameRate() until I updated to the beta. It is documented in https://github.com/AdobeDocs/uxp-premiere-pro-samples/ that this was introduced in v26.2 (beta).

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
