### PR TITLE
docs: Add Changelog entry for Premiere 26.3

### DIFF
--- a/src/pages/changelog/index.md
+++ b/src/pages/changelog/index.md
@@ -7,9 +7,85 @@ keywords:
   - Release Notes
 contributors:
   - https://github.com/undavide
+  - https://github.com/camlegleiter
 ---
 
 # Changelog
+
+## Premiere Pro v26.3.0
+
+### Breaking Changes
+
+#### Sequence.setSelection
+
+The `Sequence.setSelection` method is now **synchronous**: calling this will immediately return a `boolean` value instead of a `Promise<boolean>`.
+
+If you are using this API with `async`/`await`, simply remove the use of `await`:
+
+```diff
+  const project = await ppro.Project.getActiveProject();
+  const sequence = await project.getActiveSequence();
+
+  const selection = await sequence.getSelection();
+
+- const success = await sequence.setSelection(selection);
++ const success = sequence.setSelection(selection);
+```
+
+If you are using this API with `Promise.then` method chaining, you'll need a bit more updating to avoid runtime issues, e.g.:
+
+```diff
+- sequence.setSelection(selection).then((success) => {
+-   if (success) { ... }
+- });
++ const success = sequence.setSelection(selection);
++ if (success) { ... }
+```
+
+#### Action creation in locks
+
+Creating `Action` instances through the various `create*Action` functions must now be done so while behind a `project.lockedAccess(() => { ... })` call. Previously this wasn't consistently enforced across `create*Action` calls.
+
+```ts
+const audioTrack: AudioTrack = ...
+
+project.lockedAccess(() => {
+  // Create the action here...
+  const action = audioTrack.createSetNameAction("MyAudioTrack");
+
+  project.executeTransasction((compoundAction: CompoundAction) => {
+    // ...and use it here
+    compoundAction.addAction(action);
+  }, "Rename AudioTrack");
+});
+```
+
+Creating `Action`s within a `lockedAccess` call is important: many `Action`s contain data that can quickly become stale or inconsistent with other actions that might take place in Premiere (e.g., an editor is making changes that might conflict with a UXP plugin operating at the same time). Using the `lockedAccess` makes sure these actions are sequenced and properly applied to the Undo history.
+
+The new `@adobe/eslint-plugin-premierepro` ESLint plugin offers several rules which help catch these cases to help make sure `Action` creation and usage in your plugin follows best practices. For more information see the documentation pages for:
+- The [ESLint Support](../resources/fundamentals/eslint-support/index.md) fundamentals page
+- The [`adobe/eslint-plugin-premierepro`](https://github.com/adobe/eslint-plugin-premierepro) Github repo which includes setup and configuration details as well as docs for individual rules.
+
+### New APIs
+
+A number of new APIs have been added in this release. More details on each can be seen in each class's documentation page.
+
+- [`AudioTrack`s](../ppro-reference/classes/audiotrack.md#createsetnameaction), [`CaptionTrack`s](../ppro-reference/classes/captiontrack.md#createsetnameaction), and [`VideoTrack`s](../ppro-reference/classes/videotrack.md#createsetnameaction) can now be renamed via a `createSetNameAction` function added to each class.
+- [`ClipProjectItem.createSubClipAction`](../ppro-reference/classes/clipprojectitem.md#createsubclipaction) lets you create sub clips from the `ClipProjectItem`.
+- [`EncoderManager`](../ppro-reference/classes/encodermanager.md) has a few new functions added for helping with exporting and using AME:
+  - [`launchEncoder`](../ppro-reference/classes/encodermanager.md#launchencoder) to launch your local AME instance.
+  - [`setEmbeddedXMPEnabled`](../ppro-reference/classes/encodermanager.md#setembeddedxmpenabled) to toggle embedding XMP metadata
+  - [`setSidecarXMPEnabled`](../ppro-reference/classes/encodermanager.md#setsidecarxmpenabled) to toggle adding XMP metadata in a sidecar file
+  - [`startBatchEncode`](../ppro-reference/classes/encodermanager.md#startbatchencode) to start any queued encodes in AME
+- [`Marker`s](../ppro-reference/classes/marker.md) now have a unique `guid` property.
+- A new [`ObjectMaskUtils`](../ppro-reference/classes/objectmaskutils.md) class has been added.
+- [`Project.createSequenceWithPresetPath`](../ppro-reference/classes/project.md#createsequencewithpresetpath) has been added to compliment [`Project.createSequence`](../ppro-reference/classes/project.md#createsequence) when using a Sequence Preset.
+- A new [`ProjectConverter.exportAAF`](../ppro-reference/classes/projectconverter.md#exportaaf) export function has been added for AAF support. You can see what options are available when exporting AAF project files via the separate [`AAFExportOptions`](../ppro-reference/classes/aafexportoptions.md) class.
+- You can set the [`SourceMonitor`s](../ppro-reference/classes/sourcemonitor.md) current position using [`setPosition`](../ppro-reference/classes/sourcemonitor.md#setposition).
+- [`Transcript`](../ppro-reference/classes/transcript.md) has added functions for working with transcriptions.
+  - [`querySupportedLanguages`](../ppro-reference/classes/transcript.md#querysupportedlanguages) to see what language packs are currently available
+  - [`hasTranscript`](../ppro-reference/classes/transcript.md#hastranscript) to check if a `ClipProjectItem` has already been transcribed
+
 
 ## Premiere Pro v26.2.0
 

--- a/src/pages/changelog/index.md
+++ b/src/pages/changelog/index.md
@@ -14,6 +14,8 @@ contributors:
 
 ## Premiere Pro v26.3.0
 
+This release of Premiere comes with a few breaking changes we want to call out, as well as a swath of new APIs worth looking through.
+
 ### Breaking Changes
 
 #### Sequence.setSelection
@@ -68,7 +70,7 @@ The new `@adobe/eslint-plugin-premierepro` ESLint plugin offers several rules wh
 
 ### New APIs
 
-A number of new APIs have been added in this release. More details on each can be seen in each class's documentation page.
+A number of new APIs have been added in this release. More details on each can be seen in each class's documentation page. If you'd like to see more examples of using all of these new APIs in action, check out the `premiere-api` sample panel in the [UXP Premiere Pro Samples](https://github.com/AdobeDocs/uxp-premiere-pro-samples) repository.
 
 - [`AudioTrack`s](../ppro-reference/classes/audiotrack.md#createsetnameaction), [`CaptionTrack`s](../ppro-reference/classes/captiontrack.md#createsetnameaction), and [`VideoTrack`s](../ppro-reference/classes/videotrack.md#createsetnameaction) can now be renamed via a `createSetNameAction` function added to each class.
 - [`ClipProjectItem.createSubClipAction`](../ppro-reference/classes/clipprojectitem.md#createsubclipaction) lets you create sub clips from the `ClipProjectItem`.
@@ -81,7 +83,7 @@ A number of new APIs have been added in this release. More details on each can b
 - A new [`ObjectMaskUtils`](../ppro-reference/classes/objectmaskutils.md) class has been added.
 - [`Project.createSequenceWithPresetPath`](../ppro-reference/classes/project.md#createsequencewithpresetpath) has been added to compliment [`Project.createSequence`](../ppro-reference/classes/project.md#createsequence) when using a Sequence Preset.
 - A new [`ProjectConverter.exportAAF`](../ppro-reference/classes/projectconverter.md#exportaaf) export function has been added for AAF support. You can see what options are available when exporting AAF project files via the separate [`AAFExportOptions`](../ppro-reference/classes/aafexportoptions.md) class.
-- You can set the [`SourceMonitor`s](../ppro-reference/classes/sourcemonitor.md) current position using [`setPosition`](../ppro-reference/classes/sourcemonitor.md#setposition).
+- You can set the [`SourceMonitor`'s](../ppro-reference/classes/sourcemonitor.md) current position using [`setPosition`](../ppro-reference/classes/sourcemonitor.md#setposition).
 - [`Transcript`](../ppro-reference/classes/transcript.md) has added functions for working with transcriptions.
   - [`querySupportedLanguages`](../ppro-reference/classes/transcript.md#querysupportedlanguages) to see what language packs are currently available
   - [`hasTranscript`](../ppro-reference/classes/transcript.md#hastranscript) to check if a `ClipProjectItem` has already been transcribed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adding a Changelog entry for updates as of 26.3, focused on breaking changes and API additions.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

So we can let the developers know what all's been going on!

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified that everything comes up locally. The only unfortunate downside is that `diff` code blocks aren't supported so the fancy coloring used in the breaking changes section doesn't quite come up nicely.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
