### PR TITLE
docs(ppro-reference): Update Project.saveAs description

### DIFF
--- a/src/pages/ppro-reference/classes/project.md
+++ b/src/pages/ppro-reference/classes/project.md
@@ -407,7 +407,7 @@ Returns: Promise\<*boolean*\>
 
 ### saveAs
 
-Save the project at the provided path
+Saves a copy of the project at the provided path, mirroring the 'File > Save As' behavior in Premiere Pro: the newly saved copy becomes the active project, just as it would after using 'Save As' in the application. Separately, and perhaps unexpectedly, the `Project` object `saveAs()` was called on is itself updated in place to represent that new copy. It does not stay pinned to the original project file. This also affects chained calls, meaning calling `saveAs()` again on the same object saves a copy of that new file, not the original. To continue working with the original project--for example, to derive several independent copies from the same source--reopen it explicitly via `Project.open()` before each subsequent `saveAs()` call, rather than assuming the existing handle still refers to it.
 
 Since: **25.6**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Updating the description text for `Project.saveAs` to be more clear as to how it works and the side effects from invoking it successfully. This description will also be applied to the TypeScript declarations package.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This should help address a callout from https://github.com/AdobeDocs/uxp-premiere-pro-samples/issues/84

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See repro steps in the original issue.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Doc change

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
